### PR TITLE
Fix missing AttentiveReservoir import in trainer

### DIFF
--- a/lsm_lite/training/dual_cnn_trainer.py
+++ b/lsm_lite/training/dual_cnn_trainer.py
@@ -42,6 +42,11 @@ try:
 except ImportError:
     from lsm_lite.core.rolling_wave_storage import RollingWaveStorage, WaveStorageError
 
+try:
+    from ..core.attentive_reservoir import AttentiveReservoir
+except ImportError:
+    from lsm_lite.core.attentive_reservoir import AttentiveReservoir
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- include AttentiveReservoir in dual CNN trainer dependencies so forward passes can detect attentive reservoir correctly

## Testing
- `pytest tests/test_attentive_reservoir.py::TestAttentiveReservoir::test_initialization -q`
- `python examples/parquet_dual_cnn_training_demo.py` (initialization and training logs show no AttentiveReservoir name errors)


------
https://chatgpt.com/codex/tasks/task_e_689a87321568832baa02056f3898ae19